### PR TITLE
Update BluetoothChatService.java

### DIFF
--- a/BluetoothChatMulti/src/com/example/android/BluetoothChatMulti/BluetoothChatService.java
+++ b/BluetoothChatMulti/src/com/example/android/BluetoothChatMulti/BluetoothChatService.java
@@ -278,6 +278,11 @@ public class BluetoothChatService {
 	                    mSockets.add(socket);
 	                    mDeviceAddresses.add(address);
 	                    connected(socket, socket.getRemoteDevice());
+	                    //Unlike TCP/IP, RFCOMM only allows one connected client per channel at a time, so in most cases it makes sense to 
+	                    //call close() on the BluetoothServerSocket immediately after accepting a connected socket.
+	                    if(serverSocket != null){
+	                    	serverSocket.close();
+	                    }
                     }	                    
             	}
             } catch (IOException e) {


### PR DESCRIPTION
Existing code has some issue with multiple device connection. When I am trying connect first time then it will work perfect but after disconnecting and connecting again then it will only allows to connect 2 devices. For solving this issue I had updated the BluetoothChatService, in AcceptThread class where we are checking for the all uuid and initializing the BluetoothServerSocket after accepting connection we need to close BluetoothServerSocket because TCP/IP, RFCOMM only allows one connected client per channel at a time so in most cases it makes sense to call close() on the BluetoothServerSocket immediately after accepting a connected socket.
